### PR TITLE
Adds IFOPT-ID validator for stop IDs

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -10,3 +10,5 @@ validator.TooFastTravelValidator.errorSpeedMultiplier=2
 validator.TooFastTravelValidator.maxSpeedKph.3=60
 
 validator.CalendarValidator.expiredCutoffDate=2020/12/31
+
+validator.IFOPTStopIDStreamingValidator.enabled=false

--- a/config.properties
+++ b/config.properties
@@ -10,5 +10,3 @@ validator.TooFastTravelValidator.errorSpeedMultiplier=2
 validator.TooFastTravelValidator.maxSpeedKph.3=60
 
 validator.CalendarValidator.expiredCutoffDate=2020/12/31
-
-validator.IFOPTStopIDStreamingValidator.enabled=false

--- a/src/main/java/com/mecatran/gtfsvtor/validation/ValidatorConfig.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/ValidatorConfig.java
@@ -6,6 +6,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import com.mecatran.gtfsvtor.model.GtfsLogicalDate;
 
@@ -73,6 +75,17 @@ public interface ValidatorConfig {
 					cal.get(Calendar.MONTH) + 1,
 					cal.get(Calendar.DAY_OF_MONTH));
 		} catch (ParseException e) {
+			return defaultValue;
+		}
+	}
+
+	public default Pattern getPattern(String key, Pattern defaultValue) {
+		String str = this.getString(key);
+		if (str == null || str.isEmpty())
+			return defaultValue;
+		try {
+			return Pattern.compile(str);
+		} catch (PatternSyntaxException e) {
 			return defaultValue;
 		}
 	}

--- a/src/main/java/com/mecatran/gtfsvtor/validation/impl/ValidatorInjector.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/impl/ValidatorInjector.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
@@ -194,6 +195,8 @@ public class ValidatorInjector<T> {
 						value = new Boolean((boolean) value);
 				} else if (fieldType.equals(GtfsLogicalDate.class)) {
 					value = config.getLogicalDate(configKey, null);
+				} else if (fieldType.equals(Pattern.class)) {
+					value = config.getPattern(configKey, null);
 				} else {
 					System.err.println("Cannot configure validator "
 							+ validator.getClass().getSimpleName()

--- a/src/main/java/com/mecatran/gtfsvtor/validation/streaming/IFOPTStopIDStreamingValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/streaming/IFOPTStopIDStreamingValidator.java
@@ -6,12 +6,14 @@ import com.mecatran.gtfsvtor.reporting.ReportIssueSeverity;
 import com.mecatran.gtfsvtor.reporting.ReportSink;
 import com.mecatran.gtfsvtor.reporting.issues.InvalidFieldFormatError;
 import com.mecatran.gtfsvtor.validation.ConfigurableOption;
+import com.mecatran.gtfsvtor.validation.DefaultDisabledValidator;
 import com.mecatran.gtfsvtor.validation.StreamingValidateType;
 import com.mecatran.gtfsvtor.validation.StreamingValidator;
 
 import java.util.regex.Pattern;
 
 @StreamingValidateType(GtfsStop.class)
+@DefaultDisabledValidator
 public class IFOPTStopIDStreamingValidator implements StreamingValidator<GtfsStop> {
 
 	@ConfigurableOption(description = "Pattern the stop_id must conform to for stops of stop_type station")

--- a/src/main/java/com/mecatran/gtfsvtor/validation/streaming/IFOPTStopIDStreamingValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/streaming/IFOPTStopIDStreamingValidator.java
@@ -1,0 +1,48 @@
+package com.mecatran.gtfsvtor.validation.streaming;
+
+import com.mecatran.gtfsvtor.model.GtfsStop;
+import com.mecatran.gtfsvtor.model.GtfsStopType;
+import com.mecatran.gtfsvtor.reporting.ReportIssueSeverity;
+import com.mecatran.gtfsvtor.reporting.ReportSink;
+import com.mecatran.gtfsvtor.reporting.issues.InvalidFieldFormatError;
+import com.mecatran.gtfsvtor.validation.ConfigurableOption;
+import com.mecatran.gtfsvtor.validation.StreamingValidateType;
+import com.mecatran.gtfsvtor.validation.StreamingValidator;
+
+import java.util.regex.Pattern;
+
+@StreamingValidateType(GtfsStop.class)
+public class IFOPTStopIDStreamingValidator implements StreamingValidator<GtfsStop> {
+
+	@ConfigurableOption(description = "Pattern the stop_id must conform to for stops of stop_type station")
+	public Pattern stationTypeStopIdPattern = Pattern.compile("[a-z]{2}:\\d+:\\d+");
+
+	@ConfigurableOption(description = "Pattern the stop_id must conform to for stops of stop_type stop")
+	public Pattern stopTypeStopIdPattern = Pattern.compile("[a-z]{2}:\\d+:\\d+:\\d*:[A-Za-z0-9]+(:[A-Za-z0-9]+)?");
+
+	@ConfigurableOption(description = "Pattern the stop_id must conform to for stops of stop_type entrance")
+	public Pattern entranceTypeStopIdPattern = Pattern.compile("[a-z]{2}:\\d+:\\d+:\\d*:[A-Za-z0-9]+(:[A-Za-z0-9]+)?");
+
+	@Override
+	public void validate(Class<? extends GtfsStop> clazz, GtfsStop stop,
+			Context context) {
+		ReportSink reportSink = context.getReportSink();
+		GtfsStopType stopType = stop.getType();
+		boolean namePosMandatory = stopType == GtfsStopType.STOP || stopType == GtfsStopType.STATION
+				|| stopType == GtfsStopType.ENTRANCE;
+		String stopId = stop.getId().getInternalId();
+		if (stopType == GtfsStopType.STOP && !stopTypeStopIdPattern.matcher(stopId).matches()) {
+			reportSink.report(new InvalidFieldFormatError(context.getSourceInfo(), "stop_id",
+					"stop_id does not conform to expected format", stopTypeStopIdPattern.toString())
+					.withSeverity(ReportIssueSeverity.WARNING));
+		} else if (stopType == GtfsStopType.STATION && !stationTypeStopIdPattern.matcher(stopId).matches()) {
+			reportSink.report(new InvalidFieldFormatError(context.getSourceInfo(), "stop_id",
+					"stop_id does not conform to expected format",
+					stationTypeStopIdPattern.toString()).withSeverity(ReportIssueSeverity.WARNING));
+		} else if (stopType == GtfsStopType.ENTRANCE && !entranceTypeStopIdPattern.matcher(stopId).matches()) {
+			reportSink.report(new InvalidFieldFormatError(context.getSourceInfo(), "stop_id",
+					"stop_id does not conform to expected format",
+					entranceTypeStopIdPattern.toString()).withSeverity(ReportIssueSeverity.WARNING));
+		}
+	}
+}


### PR DESCRIPTION
This in-work PR adds a streaming validator to check that stop_ids are valid IFOPT-Ids.

Current questions: 
1) I'm not aware of an official regex for IFOPT-Ids. Especially quay identifiers seem to be unstandardized (Umlauts, spaces. underscores, hyphen and the like)
2) Currently many tests fail as I reuse the InvalidFieldFormatError and IFOPTStopIDStreamingValidator is enabled in the tests by default. Not sure, what would be the best way to proceed here. Perhaps placing such custom validators in a special package which is disabled by default?
3) Is setting `validator.IFOPTStopIDStreamingValidator.enabled=false` in `config.properties` sufficient to prevent others from unexpected default behavior? Again placing it in an `extension` package disabled by default might be preferable.
