### PR TITLE
Establish backward-compatibility for route name start check

### DIFF
--- a/TODO
+++ b/TODO
@@ -16,7 +16,6 @@ Invalid float value (comma instead of point, exponent notation)
 
 Routes
 ------
-Backward compat: Route long name should not start with short name: "O" vs "ORLEANS xxx" raises an error but do not in existing validator. Take space into account? And/or min length?
 
 Stops
 -----

--- a/src/main/java/com/mecatran/gtfsvtor/validation/streaming/RouteStreamingValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/streaming/RouteStreamingValidator.java
@@ -51,9 +51,16 @@ public class RouteStreamingValidator implements StreamingValidator<GtfsRoute> {
 							"Max " + maxShortNameLen + " chars long")
 									.withSeverity(ReportIssueSeverity.WARNING));
 		}
-		if (route.getShortName() != null && route.getLongName() != null
-				&& route.getLongName().startsWith(route.getShortName())) {
-			// TODO Are we sure about this test?
+		String lowercaseShortName = route.getShortName() != null ?
+				route.getShortName().toLowerCase().trim() : null;
+		String lowercaseLongName =
+				route.getLongName() != null ? route.getLongName().toLowerCase().trim() :
+						null;
+		if (lowercaseShortName != null && lowercaseLongName != null && (
+				lowercaseLongName.equals(lowercaseShortName)
+						|| lowercaseLongName.startsWith(lowercaseShortName + " ")
+						|| lowercaseLongName.startsWith(lowercaseShortName + "(")
+						|| lowercaseLongName.startsWith(lowercaseShortName + "-"))) {
 			// TODO specific report for this for better explanation
 			reportSink.report(new InvalidFieldValueIssue(
 					context.getSourceInfo(), route.getShortName(),

--- a/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
+++ b/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
@@ -1054,7 +1054,7 @@ public class TestGtfs {
 		assertEquals(1, iffs.size());
 		List<InvalidFieldValueIssue> ifvs = tb.report
 				.getReportIssues(InvalidFieldValueIssue.class);
-		assertEquals(2, ifvs.size());
+		assertEquals(1, ifvs.size());
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes #10. A route_long_name is considered to have the same start as the route_short_name if the lowercase long_name starts with the lowercased short_name plus either whitespace, bracket or hyphen.

The original validator distinguish between name equality and same start. Not sure if that is really necessary.

