### PR TITLE
Adds GtfsStops.getValidCoordinates()

### DIFF
--- a/src/main/java/com/mecatran/gtfsvtor/model/GtfsStop.java
+++ b/src/main/java/com/mecatran/gtfsvtor/model/GtfsStop.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
 
+import org.locationtech.jts.shape.GeometricShapeBuilder;
+
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
 
 public class GtfsStop implements GtfsObject<String>, GtfsObjectWithSourceRef {
@@ -27,6 +29,8 @@ public class GtfsStop implements GtfsObject<String>, GtfsObjectWithSourceRef {
 	private String platformCode;
 
 	private long sourceLineNumber;
+
+	private transient Optional<GeoCoordinates> cachedCoordinates;
 
 	public GtfsStop.Id getId() {
 		return id;
@@ -81,18 +85,39 @@ public class GtfsStop implements GtfsObject<String>, GtfsObjectWithSourceRef {
 
 	/**
 	 * @return The coordinates associated to this stop. If one of lat or lon is
-	 *         not defined, return null. If both lat and lon are 0.0, the
-	 *         coordinates are most likely to be bogus, we also return null
-	 *         (undefined). Otherwise return the associated position.
+	 *         not defined, return null. Otherwise return the associated position.
 	 */
+	@Deprecated
 	public GeoCoordinates getCoordinates() {
 		// TODO cache this?
-		if (lat != null && lon != null && (lat != 0.0 || lon != 0.0)) {
+		if (lat != null && lon != null) {
 			return new GeoCoordinates(lat, lon);
 		} else {
 			return null;
 		}
 	}
+
+	/**
+	 * @return The coordinates associated to this stop. If one of lat or lon is
+	 *         not defined, return Optional.empty(). If both lat and lon are 0.0, the
+	 *         coordinates are most likely to be bogus, we also return Optional.empty()
+	 *         (undefined). If lat or lon exceed the world bounding box
+	 *         (-90;-180,90,180) we consider the coordinates invalid as well and return
+	 *         Optional.empty(). Otherwise return the associated position.
+	 */
+	public Optional<GeoCoordinates> getValidCoordinates() {
+		if (cachedCoordinates != null)
+			return cachedCoordinates;
+
+		if (lat != null && lon != null && (lat != 0.0 || lon != 0.0)
+				&& (-90 <= lat && lat <= 90 && -180 <= lon && lon <= 180)) {
+			cachedCoordinates = Optional.of(new GeoCoordinates(lat, lon));
+		} else {
+			cachedCoordinates = Optional.empty();
+		}
+		return cachedCoordinates;
+	}
+
 
 	public String getDescription() {
 		return description;

--- a/src/main/java/com/mecatran/gtfsvtor/model/GtfsStop.java
+++ b/src/main/java/com/mecatran/gtfsvtor/model/GtfsStop.java
@@ -5,8 +5,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
 
-import org.locationtech.jts.shape.GeometricShapeBuilder;
-
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
 
 public class GtfsStop implements GtfsObject<String>, GtfsObjectWithSourceRef {

--- a/src/main/java/com/mecatran/gtfsvtor/validation/dao/DifferentStationTooCloseValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/dao/DifferentStationTooCloseValidator.java
@@ -1,5 +1,7 @@
 package com.mecatran.gtfsvtor.validation.dao;
 
+import java.util.Optional;
+
 import com.mecatran.gtfsvtor.dao.DaoSpatialIndex;
 import com.mecatran.gtfsvtor.dao.IndexedReadOnlyDao;
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
@@ -32,20 +34,21 @@ public class DifferentStationTooCloseValidator implements DaoValidator {
 				return;
 			if (stop.getParentId() == null)
 				return;
-			GeoCoordinates pStop = stop.getCoordinates();
-			if (pStop == null)
+			Optional<GeoCoordinates> pStop = stop.getValidCoordinates();
+			if (!pStop.isPresent())
 				return;
 			GtfsStop station = dao.getStop(stop.getParentId());
 			if (station == null)
 				return;
-			GeoCoordinates pStation = station.getCoordinates();
-			if (pStation == null)
+			Optional<GeoCoordinates> pStation = station.getValidCoordinates();
+			if (!pStation.isPresent())
 				return;
-			spatialIndex.getStopsAround(pStop, maxDistanceMetersWarning, true)
+			spatialIndex.getStopsAround(pStop.get(), maxDistanceMetersWarning, true)
 					.filter(s -> s.getType() == GtfsStopType.STATION)
 					.filter(s -> !s.equals(station)).forEach(station2 -> {
-						double distance = Geodesics.distanceMeters(pStop,
-								station2.getCoordinates());
+						double distance = Geodesics.distanceMeters(pStop.get(),
+								// We expect only stops with valid coords in index
+								station2.getValidCoordinates().get());
 						reportSink.report(new DifferentStationTooCloseWarning(
 								stop, station, station2, distance));
 					});

--- a/src/main/java/com/mecatran/gtfsvtor/validation/dao/StopTooFarFromParentStationValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/dao/StopTooFarFromParentStationValidator.java
@@ -1,5 +1,7 @@
 package com.mecatran.gtfsvtor.validation.dao;
 
+import java.util.Optional;
+
 import com.mecatran.gtfsvtor.dao.ReadOnlyDao;
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
 import com.mecatran.gtfsvtor.geospatial.Geodesics;
@@ -34,8 +36,8 @@ public class StopTooFarFromParentStationValidator implements DaoValidator {
 				return;
 			if (stop.getParentId() == null)
 				return;
-			GeoCoordinates pStop = stop.getCoordinates();
-			if (pStop == null)
+			Optional<GeoCoordinates> pStop = stop.getValidCoordinates();
+			if (!pStop.isPresent())
 				return;
 			GtfsStop station = dao.getStop(stop.getParentId());
 			if (station == null)
@@ -43,10 +45,10 @@ public class StopTooFarFromParentStationValidator implements DaoValidator {
 			// Do not test distance if data is bogus
 			if (station.getType() != GtfsStopType.STATION)
 				return;
-			GeoCoordinates pStation = station.getCoordinates();
-			if (pStation == null)
+			Optional<GeoCoordinates> pStation = station.getValidCoordinates();
+			if (!pStation.isPresent())
 				return;
-			double distance = Geodesics.distanceMeters(pStop, pStation);
+			double distance = Geodesics.distanceMeters(pStop.get(), pStation.get());
 			if (distance >= maxDistanceMetersWarning
 					|| distance >= maxDistanceMetersError) {
 				reportSink.report(new StopTooFarFromParentStationIssue(stop,

--- a/src/main/java/com/mecatran/gtfsvtor/validation/streaming/PathwayStreamingValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/streaming/PathwayStreamingValidator.java
@@ -3,6 +3,8 @@ package com.mecatran.gtfsvtor.validation.streaming;
 import static com.mecatran.gtfsvtor.validation.impl.StreamingValidationUtils.checkFormat;
 import static com.mecatran.gtfsvtor.validation.impl.StreamingValidationUtils.checkNonNull;
 
+import java.util.Optional;
+
 import com.mecatran.gtfsvtor.dao.ReadOnlyDao;
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
 import com.mecatran.gtfsvtor.geospatial.Geodesics;
@@ -93,10 +95,10 @@ public class PathwayStreamingValidator
 				&& pathway.getPathwayMode() == GtfsPathwayMode.WALKWAY
 				&& pathway.getTraversalTime() != null
 				&& pathway.getTraversalTime() > 0) {
-			GeoCoordinates p1 = fromStop.getCoordinates();
-			GeoCoordinates p2 = toStop.getCoordinates();
-			if (p1 != null && p2 != null) {
-				double d = Geodesics.fastDistanceMeters(p1, p2);
+			Optional<GeoCoordinates> p1 = fromStop.getValidCoordinates();
+			Optional<GeoCoordinates> p2 = toStop.getValidCoordinates();
+			if (p1.isPresent() && p2.isPresent()) {
+				double d = Geodesics.fastDistanceMeters(p1.get(), p2.get());
 				double speedMps = d
 						/ (pathway.getTraversalTime() + walkingTimeSlackSec);
 				if (speedMps > fastWalkingSpeedMps) {

--- a/src/main/java/com/mecatran/gtfsvtor/validation/streaming/TransferStreamingValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/streaming/TransferStreamingValidator.java
@@ -2,6 +2,8 @@ package com.mecatran.gtfsvtor.validation.streaming;
 
 import static com.mecatran.gtfsvtor.validation.impl.StreamingValidationUtils.checkFormat;
 
+import java.util.Optional;
+
 import com.mecatran.gtfsvtor.dao.ReadOnlyDao;
 import com.mecatran.gtfsvtor.geospatial.GeoCoordinates;
 import com.mecatran.gtfsvtor.geospatial.Geodesics;
@@ -121,10 +123,10 @@ public class TransferStreamingValidator
 		}
 		// Check from-to stop distance and walk speed
 		if (fromStop != null && toStop != null) {
-			GeoCoordinates p1 = fromStop.getCoordinates();
-			GeoCoordinates p2 = toStop.getCoordinates();
-			if (p1 != null && p2 != null) {
-				double d = Geodesics.fastDistanceMeters(p1, p2);
+			Optional<GeoCoordinates> p1 = fromStop.getValidCoordinates();
+			Optional<GeoCoordinates> p2 = toStop.getValidCoordinates();
+			if (p1.isPresent() && p2.isPresent()) {
+				double d = Geodesics.fastDistanceMeters(p1.get(), p2.get());
 				ReportIssueSeverity severity = null;
 				if (maxDistanceMetersError > 0 && d > maxDistanceMetersError) {
 					severity = ReportIssueSeverity.ERROR;

--- a/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
+++ b/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
@@ -87,6 +87,7 @@ import com.mecatran.gtfsvtor.reporting.issues.OverlappingBlockIdIssue;
 import com.mecatran.gtfsvtor.reporting.issues.RouteColorContrastIssue;
 import com.mecatran.gtfsvtor.reporting.issues.SimilarRouteColorWarning;
 import com.mecatran.gtfsvtor.reporting.issues.StopTooCloseIssue;
+import com.mecatran.gtfsvtor.reporting.issues.StopTooCloseToOriginError;
 import com.mecatran.gtfsvtor.reporting.issues.StopTooFarFromParentStationIssue;
 import com.mecatran.gtfsvtor.reporting.issues.StopTooFarFromShapeIssue;
 import com.mecatran.gtfsvtor.reporting.issues.TimeTravelAtStopError;
@@ -1363,6 +1364,14 @@ public class TestGtfs {
 				stf0.getProjectedPoint());
 		assertTrue(d < 1.0);
 		assertEquals(209.12, stf0.getDistanceMeters(), 1e-2);
+	}
+
+	@Test
+	public void testSwegZeroCoordinates() {
+		TestBundle tb = loadAndValidate("sweg_zero_coordinates");
+		List<StopTooCloseToOriginError> stctoes = tb.report
+				.getReportIssues(StopTooCloseToOriginError.class);
+		assertEquals(1, stctoes.size());
 	}
 
 	@Test

--- a/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
+++ b/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
@@ -777,10 +777,10 @@ public class TestGtfs {
 		GtfsStop stop0 = tb.dao.getStop(stopTimes.get(0).getStopId());
 		GtfsStop stop1 = tb.dao.getStop(stopTimes.get(1).getStopId());
 		GtfsStop stop2 = tb.dao.getStop(stopTimes.get(2).getStopId());
-		double d01 = Geodesics.distanceMeters(stop0.getCoordinates(),
-				stop1.getCoordinates());
-		double d12 = Geodesics.distanceMeters(stop1.getCoordinates(),
-				stop2.getCoordinates());
+		double d01 = Geodesics.distanceMeters(stop0.getValidCoordinates().get(),
+				stop1.getValidCoordinates().get());
+		double d12 = Geodesics.distanceMeters(stop1.getValidCoordinates().get(),
+				stop2.getValidCoordinates().get());
 		double l01 = lgi.getLinearDistance(stopTimes.get(0), stopTimes.get(1));
 		double l12 = lgi.getLinearDistance(stopTimes.get(1), stopTimes.get(2));
 		double l02 = lgi.getLinearDistance(stopTimes.get(0), stopTimes.get(2));
@@ -806,8 +806,8 @@ public class TestGtfs {
 		GtfsStop furCreek = tb.dao.getStop(GtfsStop.id("FUR_CREEK_RES"));
 		GtfsStop beattyAirport = tb.dao
 				.getStop(GtfsStop.id("BEATTY_AIRPORT_STATION"));
-		stops = dsi.getStopsAround(furCreek.getCoordinates(), 1, true)
-				.collect(Collectors.toList());
+		stops = dsi.getStopsAround(furCreek.getValidCoordinates().get(), 1,
+				true).collect(Collectors.toList());
 		assertEquals(1, stops.size());
 		assertEquals(furCreek, stops.iterator().next());
 		stops = dsi
@@ -816,14 +816,14 @@ public class TestGtfs {
 						furCreek.getLon()), 1, true)
 				.collect(Collectors.toList());
 		assertTrue(stops.isEmpty());
-		double dMax = Geodesics.distanceMeters(beattyAirport.getCoordinates(),
-				furCreek.getCoordinates());
+		double dMax = Geodesics.distanceMeters(beattyAirport.getValidCoordinates().get(),
+				furCreek.getValidCoordinates().get());
 		stops = dsi
-				.getStopsAround(beattyAirport.getCoordinates(), dMax - 1, true)
+				.getStopsAround(beattyAirport.getValidCoordinates().get(), dMax - 1, true)
 				.collect(Collectors.toList());
 		assertEquals(tb.dao.getStops().count() - 1, stops.size());
 		stops = dsi
-				.getStopsAround(beattyAirport.getCoordinates(), dMax + 1, true)
+				.getStopsAround(beattyAirport.getValidCoordinates().get(), dMax + 1, true)
 				.collect(Collectors.toList());
 		assertEquals(tb.dao.getStops().count(), stops.size());
 	}
@@ -964,10 +964,10 @@ public class TestGtfs {
 		GtfsStop s0 = dao.getStop(st0.getStopId());
 		GtfsStop s1 = dao.getStop(st1.getStopId());
 		GtfsStop s2 = dao.getStop(st2.getStopId());
-		double d01 = Geodesics.distanceMeters(s0.getCoordinates(),
-				s1.getCoordinates());
-		double d12 = Geodesics.distanceMeters(s1.getCoordinates(),
-				s2.getCoordinates());
+		double d01 = Geodesics.distanceMeters(s0.getValidCoordinates().get(),
+				s1.getValidCoordinates().get());
+		double d12 = Geodesics.distanceMeters(s1.getValidCoordinates().get(),
+				s2.getValidCoordinates().get());
 		ProjectedPoint pp0 = lgi.getProjectedPoint(st0);
 		ProjectedPoint pp1 = lgi.getProjectedPoint(st1);
 		ProjectedPoint pp2 = lgi.getProjectedPoint(st2);
@@ -995,11 +995,11 @@ public class TestGtfs {
 		assertEquals(0, pp0.getDistanceToShapeMeters(), 1e-2);
 		assertEquals(d01, pp1.getDistanceToShapeMeters(), 1e-2);
 		assertEquals(d01 + d12, pp2.getDistanceToShapeMeters(), 1e-2);
-		assertTrue(Geodesics.distanceMeters(s0.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s0.getValidCoordinates().get(),
 				pp0.getProjectedPoint()) < 1e-2);
-		assertTrue(Geodesics.distanceMeters(s0.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s0.getValidCoordinates().get(),
 				pp1.getProjectedPoint()) < 1e-2);
-		assertTrue(Geodesics.distanceMeters(s0.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s0.getValidCoordinates().get(),
 				pp2.getProjectedPoint()) < 1e-2);
 
 		/* A backtracing 2 segment shape (S1->S3->S2) */
@@ -1019,11 +1019,11 @@ public class TestGtfs {
 		assertEquals(0.0, pp0.getDistanceToShapeMeters(), 1e-2);
 		assertEquals(0.0, pp1.getDistanceToShapeMeters(), 0.2);
 		assertEquals(0.0, pp2.getDistanceToShapeMeters(), 0.4);
-		assertTrue(Geodesics.distanceMeters(s0.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s0.getValidCoordinates().get(),
 				pp0.getProjectedPoint()) < 1);
-		assertTrue(Geodesics.distanceMeters(s1.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s1.getValidCoordinates().get(),
 				pp1.getProjectedPoint()) < 1);
-		assertTrue(Geodesics.distanceMeters(s2.getCoordinates(),
+		assertTrue(Geodesics.distanceMeters(s2.getValidCoordinates().get(),
 				pp2.getProjectedPoint()) < 1);
 	}
 
@@ -1303,14 +1303,14 @@ public class TestGtfs {
 			ProjectedPoint pp = lgi.getProjectedPoint(stopTime);
 			avgDist += pp.getDistanceToShapeMeters();
 			assertTrue(pp.getDistanceToShapeMeters() < 10.0);
-			double d = Geodesics.fastDistanceMeters(stop.getCoordinates(),
+			double d = Geodesics.fastDistanceMeters(stop.getValidCoordinates().get(),
 					pp.getProjectedPoint());
 			assertEquals(pp.getDistanceToShapeMeters(), d, 1e-4);
 			if (prevStopTime != null) {
 				double ld = pp.getArcLengthMeters()
 						- prevPp.getArcLengthMeters();
 				double sd = Geodesics.fastDistanceMeters(
-						prevStop.getCoordinates(), stop.getCoordinates());
+						prevStop.getValidCoordinates().get(), stop.getValidCoordinates().get());
 				// Add 10m to take into account cases where stops are very close
 				double k = (ld + 10) / (sd + 10);
 				avgK += k;


### PR DESCRIPTION
This PR adds `Optional<GeoCoordinates> getValidCoordinates()` to GtfsStop and deprecates `getCoordinates()`. To fix #37, `getCoordinates()` returns coordinates even if lat/lon equals (0;0). 

Most calls are switched from `getCoordinates()` to getValidCoordinates()`. 

Still open: `InMemoryLinearGeometryIndex` uses `getCoordinates` in `computeShapedWithoutDistPatternIndex` and `computeLocalMins`.

I think that, if any stop has invalid coords, `computeShapedWithoutDistPatternIndex` should return null so `computeShapelessPatternIndex` is used as fallback (?) 