### PR TITLE
Extended RouteType handling for TooFastTravelValidator

### DIFF
--- a/src/main/java/com/mecatran/gtfsvtor/model/GtfsRouteType.java
+++ b/src/main/java/com/mecatran/gtfsvtor/model/GtfsRouteType.java
@@ -18,6 +18,12 @@ public class GtfsRouteType {
 	public static final int CABLE_CAR_CODE = 5;
 	public static final int GONDOLA_CODE = 6;
 	public static final int FUNICULAR_CODE = 7;
+	// Note: Intercity bus code is not yet officially adopted
+	// (see https://github.com/google/transit/pull/174)
+	// As these may have higher maxspeed values, we support them nevertheless
+	public static final int INTERCITY_BUS_CODE = 9;
+	public static final int TROLLEYBUS_CODE = 11;
+	public static final int MONORAIL_CODE = 12;
 
 	public static final GtfsRouteType TRAM = new GtfsRouteType(TRAM_CODE);
 	public static final GtfsRouteType METRO = new GtfsRouteType(METRO_CODE);
@@ -29,6 +35,12 @@ public class GtfsRouteType {
 	public static final GtfsRouteType GONDOLA = new GtfsRouteType(GONDOLA_CODE);
 	public static final GtfsRouteType FUNICULAR = new GtfsRouteType(
 			FUNICULAR_CODE);
+	public static final GtfsRouteType INTERCITY_BUS = new GtfsRouteType(
+			INTERCITY_BUS_CODE);
+	public static final GtfsRouteType TROLLEYBUS = new GtfsRouteType(
+			TROLLEYBUS_CODE);
+	public static final GtfsRouteType MONORAIL = new GtfsRouteType(
+			MONORAIL_CODE);
 
 	private static Map<Integer, GtfsRouteType> CACHE = new HashMap<>(10);
 

--- a/src/main/java/com/mecatran/gtfsvtor/model/GtfsRouteType.java
+++ b/src/main/java/com/mecatran/gtfsvtor/model/GtfsRouteType.java
@@ -56,6 +56,61 @@ public class GtfsRouteType {
 				: CACHE.computeIfAbsent(type, GtfsRouteType::new);
 	}
 
+	/**
+	 * Maps routeType (possibly defined according to google's extended route types)
+	 * to an official GTFS route type in the range between 1 and 12.
+	 * If there is no mapping defined, this function returns the unchanged route type.
+	 * Note that this function returns route type 9 (intercity bus) as well, which
+	 * is not (yet?) officially adopted in the GTFS standard.
+	 * @param routeType route type (possibly extension)
+	 * @return official GTFS route type, if mapping defined, original routeType else
+	 */
+	public static int mapExtendedToBaseRouteTypeCode(int routeType) {
+			if (routeType >= 100 && routeType < 200) {
+				return GtfsRouteType.RAIL_CODE;
+			} else if (routeType >= 200 && routeType < 300) {
+				return GtfsRouteType.INTERCITY_BUS_CODE;
+			} else if (routeType >= 300 && routeType < 400) {
+				return GtfsRouteType.RAIL_CODE;
+			} else if (routeType >= 400 && routeType < 700 || routeType == 10) {
+				// Google's 10 (Commuter train) is not yet an official routeType
+				return GtfsRouteType.METRO_CODE;
+			} else if (routeType >= 700 && routeType < 800) {
+				// Map 701 (RegionalBus), 702 (ExpressBus)
+				// 715 (Demand and Response Bus Service) and 717 (share taxi service) to
+				// INTERCITY_BUS (=> default maxSpeed 120km/h)
+				if (routeType == 701 || routeType == 702 || routeType == 715 || routeType == 717) {
+					return GtfsRouteType.INTERCITY_BUS_CODE;
+				}
+				return GtfsRouteType.BUS_CODE;
+			} else if (routeType >= 800 && routeType < 900) {
+				return GtfsRouteType.TROLLEYBUS_CODE;
+			} else if (routeType >= 900 && routeType < 1000) {
+				return GtfsRouteType.TRAM_CODE;
+			} else if (routeType >= 1000 && routeType < 1100) {
+				return GtfsRouteType.FERRY_CODE;
+			} else if (routeType >= 1100 && routeType < 1200) {
+				// No base type for airborne travel
+			} else if (routeType >= 1200 && routeType < 1300) {
+				return GtfsRouteType.FERRY_CODE;
+			} else if (routeType >= 1300 && routeType < 1400) {
+				return GtfsRouteType.GONDOLA_CODE;
+			} else if (routeType >= 1400 && routeType < 1500) {
+				return GtfsRouteType.FUNICULAR_CODE;
+			} else if (routeType >= 1500 && routeType < 1600) {
+				// Taxis are no buses, but that looks like closest match
+				// and is in line with feedvalidator's maxSpeed 100 km/h
+				return GtfsRouteType.BUS_CODE;
+			} else if (routeType >= 1600 && routeType < 1700) {
+				// No base type for self drive travel, return unchanged
+			} else if (routeType == 1701) {
+				return GtfsRouteType.CABLE_CAR_CODE;
+			}
+			// Horse Carriage (8), Horse Drawn Carriage(1702) and all other unknown
+			// codes are returned as is, resulting in default handling
+			return routeType;
+	}
+
 	public int getValue() {
 		return value;
 	}

--- a/src/main/java/com/mecatran/gtfsvtor/validation/triptimes/TooFastTravelValidator.java
+++ b/src/main/java/com/mecatran/gtfsvtor/validation/triptimes/TooFastTravelValidator.java
@@ -134,52 +134,9 @@ public class TooFastTravelValidator implements TripTimesValidator {
 		return maxSpeedMps;
 	}
 
-	private int mapExtendedToBaseRouteType(int routeType) {
-		if (routeType >= 100 && routeType < 200) {
-			return GtfsRouteType.RAIL_CODE;
-		} else if (routeType >= 200 && routeType < 300) {
-			return GtfsRouteType.INTERCITY_BUS_CODE;
-		} else if (routeType >= 300 && routeType < 400) {
-			return GtfsRouteType.RAIL_CODE;
-		} else if (routeType >= 400 && routeType < 700 || routeType == 10) {
-			// Google's 10 (Communter train) is not yet an official routeType
-			return GtfsRouteType.METRO_CODE;
-		} else if (routeType >= 700 && routeType < 800) {
-			// Note: Google's Feedvalidator handles 701 (RegionalBus), 702 (ExpressBus)
-			// 715 (Demand and Response Bus Service) and 717 (share taxi service) as
-			// INTERCITY_BUS (=> maxSpeed 120km/h)
-			return GtfsRouteType.BUS_CODE;
-		} else if (routeType >= 800 && routeType < 900) {
-			return GtfsRouteType.TROLLEYBUS_CODE;
-		} else if (routeType >= 900 && routeType < 1000) {
-			return GtfsRouteType.TRAM_CODE;
-		} else if (routeType >= 1000 && routeType < 1100) {
-			return GtfsRouteType.FERRY_CODE;
-		} else if (routeType >= 1100 && routeType < 1200) {
-			// No base type for airborne travel
-		} else if (routeType >= 1200 && routeType < 1300) {
-			return GtfsRouteType.FERRY_CODE;
-		} else if (routeType >= 1300 && routeType < 1400) {
-			return GtfsRouteType.GONDOLA_CODE;
-		} else if (routeType >= 1400 && routeType < 1500) {
-			return GtfsRouteType.FUNICULAR_CODE;
-		} else if (routeType >= 1500 && routeType < 1600) {
-			// Taxis are no buses, but that looks like closest match
-			// and is in line with feedvalidator's maxSpeed 100 km/h
-			return GtfsRouteType.BUS_CODE;
-		} else if (routeType >= 1600 && routeType < 1700) {
-			// No base type for self drive travel, return unchanged
-		} else if (routeType == 1701) {
-			return GtfsRouteType.CABLE_CAR_CODE;
-		}
-		// Horse Carriage (8), Horse Drawn Carriage(1702) and all other unknown
-		// codes are returned as is, resulting in default handling
-		return routeType;
-	}
-
 	private double getMaxSpeedMps(int routeTypeCode, ValidatorConfig config) {
 		double maxSpeedKph;
-		switch (mapExtendedToBaseRouteType(routeTypeCode)) {
+		switch (GtfsRouteType.mapExtendedToBaseRouteTypeCode(routeTypeCode)) {
 		default:
 		case GtfsRouteType.CABLE_CAR_CODE:
 		case GtfsRouteType.GONDOLA_CODE:

--- a/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
+++ b/src/test/java/com/mecatran/gtfsvtor/test/TestGtfs.java
@@ -55,6 +55,7 @@ import com.mecatran.gtfsvtor.model.GtfsStopType;
 import com.mecatran.gtfsvtor.model.GtfsTransfer;
 import com.mecatran.gtfsvtor.model.GtfsTransferType;
 import com.mecatran.gtfsvtor.model.GtfsTrip;
+import com.mecatran.gtfsvtor.model.GtfsTripAndTimes;
 import com.mecatran.gtfsvtor.model.GtfsTripDirectionId;
 import com.mecatran.gtfsvtor.model.GtfsTripStopSequence;
 import com.mecatran.gtfsvtor.reporting.ReportIssueSeverity;
@@ -1355,10 +1356,11 @@ public class TestGtfs {
 				tb.report.issuesCountOfSeverity(ReportIssueSeverity.CRITICAL));
 		List<TooFastTravelIssue> tftis = tb.report
 				.getReportIssues(TooFastTravelIssue.class);
-		assertEquals(1, tftis.size());
-		TooFastTravelIssue tfti0 = tftis.get(0);
-		assertEquals(14.66, tfti0.getSpeedMps(), 1e-2);
-		assertEquals(439.81, tfti0.getDistanceMeters(), 1e-2);
+		assertEquals(0, tftis.size());
+		GtfsTripAndTimes trip = tb.dao.getTripAndTimes(GtfsTrip.id("74431429"));
+		List<GtfsStopTime> stopTimes = trip.getStopTimes();
+		assertEquals(439.81, tb.dao.getLinearGeometryIndex()
+				.getLinearDistance(stopTimes.get(12), stopTimes.get(13)), 1e-2);
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds handling of extended route types to TooFastTravelValidator and fixes #35.

It 
* adds the new official route types 11 and 12 ([adopted in 02/2020](https://github.com/google/transit/pull/174))
* adds the not yet officially supported, nevertheless IMHO helpful route type 9 (intercity bus), which results in a higher max speed of 120km/h in [transitfeed/feedvalidator googletransit extensions](https://github.com/google/transitfeed/blob/master/extensions/googletransit/route.py)
* handles [Google's extended route types](https://developers.google.com/transit/gtfs/reference/extended-route-types) by falling back to a 1 or 2 digit base type for which default max speeds are defined. 

Note: horse drawn carriages are implicitly handled by falling back to default speed of 50km/h (yielding same result as Feedvalidator), airborne route types are not yet supported.

@laurentg I set this PR to WIP as this PR makes testAachener74431429 fail. It's TooFastTavelIssue was explicitly tested for, though route type 704 now falls back to bus (100km/h) and not default (50km/h). Could you give some context?