### PR TITLE
tweak & fix Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 build/
 .*/
 gradle/
+
+/Dockerfile
+/.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 build/
 .*/
+!.git
 gradle/
 
 /Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM gradle:jdk11 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle build
+RUN unzip -d /app build/distributions/gtfsvtor.zip
 
-FROM openjdk:11-jre
+FROM openjdk:11-jre-slim
 LABEL maintainer="Holger Bruch holger.bruch@mitfahrdezentrale.de"
 
-COPY --from=build /home/gradle/src/build/distributions/* /app/
-RUN unzip -d /app /app/gtfsvtor.zip
+COPY --from=build /app /app
 WORKDIR /data
 
 ENV GTFSVTOR_OPTS=-Xmx4G


### PR DESCRIPTION
Currently, the Docker build is broken because `build.gradle` uses `git rev-parse HEAD` but `.git` isn't available within the `build` context.

- da24e0c contains the actual fix.
- 70907c3 improves some minor things in the docker build.